### PR TITLE
Update Handler from iPython to Jupyterlab

### DIFF
--- a/jupyterlab_multicontents_templates/handlers.py
+++ b/jupyterlab_multicontents_templates/handlers.py
@@ -5,8 +5,7 @@ import urllib.parse
 
 import nbformat
 import tornado
-from IPython.html.base.handlers import IPythonHandler
-from jupyter_server.base.handlers import APIHandler
+from jupyter_server.base.handlers import APIHandler, JupyterHandler
 from jupyter_server.utils import url_path_join
 from multicontents import MultiContentsManager
 from nbconvert import HTMLExporter
@@ -50,7 +49,7 @@ class ContentHandler(BaseMixin, APIHandler):
         self.finish(self.to_json(self.get_notebook(path)))
 
 
-class PreviewHandler(BaseMixin, IPythonHandler):
+class PreviewHandler(BaseMixin, JupyterHandler):
     def get(self):
         path = self.get_argument("path")
         html_exporter = HTMLExporter()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_multicontents_templates",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Jupyterlab templates from different types of contentsmanager ",
   "keywords": [
     "jupyter",

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup_args = dict(
         "tornado",
         "jupyter_server",
         "IPython",
+        "jupyter_packaging~=0.7.9"
     ],
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
 Update Handler from iPython to Jupyterlab where it has been moved to in later versions of iPython, bump version to 0.4.2